### PR TITLE
Fix AttributeError in PopupViewOptionsFlow initialization

### DIFF
--- a/custom_components/popup_view/config_flow.py
+++ b/custom_components/popup_view/config_flow.py
@@ -56,7 +56,8 @@ class PopupViewOptionsFlow(config_entries.OptionsFlow):
 
     def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
         """Initialize options flow."""
-        self.config_entry = config_entry
+        # Use a private attribute to avoid conflict with the config_entry property
+        self._config_entry = config_entry
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
@@ -68,7 +69,7 @@ class PopupViewOptionsFlow(config_entries.OptionsFlow):
         options = {
             vol.Optional(
                 "debug_mode",
-                default=self.config_entry.options.get("debug_mode", False),
+                default=self._config_entry.options.get("debug_mode", False),
             ): bool,
         }
 


### PR DESCRIPTION
## Problem
The `PopupViewOptionsFlow` class causes an `AttributeError: property 'config_entry' of 'PopupViewOptionsFlow' object has no setter` when trying to configure the integration through the UI.

This happens because `config_entries.OptionsFlow` already has a read-only property called `config_entry`, and the `__init__` method tries to assign to it directly.

## Error Stack Trace
File "/config/custom_components/popup_view/config_flow.py", line 59, in init
self.config_entry = config_entry
^^^^^^^^^^^^^^^^^
AttributeError: property 'config_entry' of 'PopupViewOptionsFlow' object has no setter

## Solution
Rename the internal attribute from `self.config_entry` to `self._config_entry` to avoid collision with the parent class's read-only property.

## Changes
- Line 59: Changed `self.config_entry = config_entry` to `self._config_entry = config_entry`
- Line 70: Changed `self.config_entry.options.get(...)` to `self._config_entry.options.get(...)`

## Testing
- Successfully loads config flow without 500 error
- Options flow works correctly
- Debug mode setting is persisted properly

## Environment
- Home Assistant Core: 2025.x / 2026.x (Python 3.13)

